### PR TITLE
Fixes for Sitecore 8

### DIFF
--- a/ClientEventTracker.ashx.cs
+++ b/ClientEventTracker.ashx.cs
@@ -3,13 +3,14 @@ using System.Web;
 using Sitecore.Analytics;
 using Sitecore.Analytics.Data;
 using Sitecore.Diagnostics;
+using System.Web.SessionState;
 
 namespace Sitecore.SharedSource.ClientEventTracker
 {
     /// <summary>
     /// Summary description for ClientEventTracker
     /// </summary>
-    public class ClientEventTracker : IHttpHandler
+    public class ClientEventTracker : IHttpHandler, IRequiresSessionState
     {
         public void ProcessRequest(HttpContext context)
         {

--- a/ClientEventTracker.ashx.cs
+++ b/ClientEventTracker.ashx.cs
@@ -40,7 +40,7 @@ namespace Sitecore.SharedSource.ClientEventTracker
 
                 if (!Tracker.IsActive || Tracker.Current == null)
                 {
-                    Tracker.StartTracking();
+                    Tracker.Initialize(); // init tracker without tracking the endpoint as a page
                 }
 
                 if (Tracker.Current == null || Tracker.Current.Interaction == null)
@@ -48,7 +48,7 @@ namespace Sitecore.SharedSource.ClientEventTracker
                     return;
                 }
 
-                if (Tracker.Current.Interaction.PreviousPage == null)
+                if (Tracker.Current.Interaction.CurrentPage == null)
                 {
                     return;
                 }
@@ -56,13 +56,13 @@ namespace Sitecore.SharedSource.ClientEventTracker
 
                 if (string.IsNullOrEmpty(text))
                 {
-                    Tracker.Current.Interaction.PreviousPage.Register(eventName, string.Empty);
+                    Tracker.Current.Interaction.CurrentPage.Register(eventName, string.Empty);
                 }
                 else
                 {
                     if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(data))
                     {
-                        Tracker.Current.Interaction.PreviousPage.Register(eventName, text);
+                        Tracker.Current.Interaction.CurrentPage.Register(eventName, text);
                         return;
                     }
 
@@ -72,7 +72,7 @@ namespace Sitecore.SharedSource.ClientEventTracker
                         Data = data,
                         Text = text
                     };
-                    Tracker.Current.Interaction.PreviousPage.Register(eventData);
+                    Tracker.Current.Interaction.CurrentPage.Register(eventData);
                     return;
 
                 }


### PR DESCRIPTION
- use Tracker.Initialize() instead of Tracker.StartTracking() - this prevents xDB from recording the AJAX endpoint as a page
- using Initialize() also causes the page context to not advance, thus we need CurrentPage instead of PreviousPage

Tested on SC8 Update-2. This may also work for 7.5 but I don't have an instance handy to test with.
